### PR TITLE
Switch to the archive.debian.org jessie repository (fixes #99)

### DIFF
--- a/GB-PCx/scripts/jessie_3.10.14/debian-jessie-install
+++ b/GB-PCx/scripts/jessie_3.10.14/debian-jessie-install
@@ -11,7 +11,7 @@ failed(){
 debian_install(){
   mkdir -p /tmp/newroot
   mount -t ext4 ${1} /tmp/newroot
-  debootstrap --arch=mipsel --include=vim,openssh-server,ntpdate,cron,locales,udev,ca-certificates,apt-transport-https,vlan jessie /tmp/newroot http://httpredir.debian.org/debian || failed debootstrap
+  debootstrap --arch=mipsel --include=vim,openssh-server,ntpdate,cron,locales,udev,ca-certificates,apt-transport-https,vlan jessie /tmp/newroot http://archive.debian.org/debian/ || failed debootstrap
 }
 
 debian_fix(){


### PR DESCRIPTION
The mipsel architecture for jessie has been removed from the mirror network:

  https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html