### PR TITLE
Set eth0.1 to 192.168.10.1 to match LibreCMC config

### DIFF
--- a/GB-PCx/scripts/jessie_3.10.14/debian-jessie-install
+++ b/GB-PCx/scripts/jessie_3.10.14/debian-jessie-install
@@ -22,7 +22,7 @@ iface lo inet loopback
 
 auto eth0.1
 iface eth0.1 inet static   
-    address 192.168.1.1
+    address 192.168.10.1
     netmask 255.255.255.0  
 
 auto eth0.2


### PR DESCRIPTION
This makes the black LAN port in the post-install Debian system the same as the LibreCMC image that had to be installed first.

This was reported in https://github.com/gnubee-git/GnuBee_Docs/issues/58#issuecomment-443674337 (last bullet point).